### PR TITLE
type bool as booleans instead of strings in get_types_from_catalog

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -558,7 +558,7 @@ class Reader:
         streams = next(c for c in catalog["streams"] if c["stream"] == stream)
         types = streams["schema"]["properties"]
 
-        type_mapper = {"integer": "Int64", "number": float}
+        type_mapper = {"integer": "Int64", "number": float, "boolean": bool}
 
         dtype = {}
         parse_dates = []


### PR DESCRIPTION
The function `get_types_from_catalog` was converting boolean type to strings.
This PR fixes that.