### PR TITLE
fix singer parsing for columns with dtype object

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -519,7 +519,9 @@ class Reader:
         if catalog and catalog_types:
             types_params = self.get_types_from_catalog(catalog, stream)
             kwargs.update(types_params)
-        return pd.read_csv(filepath, **kwargs)
+        df = pd.read_csv(filepath, **kwargs)
+        df = parse_object_cols(df)
+        return df
 
     def get_metadata(self, stream):
         """Get metadata from parquet file."""
@@ -650,3 +652,14 @@ def localize_datetime(df, column_name):
         df[column_name] = df[column_name].dt.tz_convert('UTC')
 
     return df[column_name]
+
+
+def parse_object_cols(df):
+    object_columns = [column for column in df.columns if df[column].dtype == 'object']
+    for col in object_columns:
+        try:
+            df[col] = df[col].apply(lambda x: parse_objs(x))
+        except:
+            continue
+    return df
+

--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -562,17 +562,19 @@ class Reader:
     def get(self, stream, default=None, catalog_types=False, parse_objects=False, **kwargs):
         """Read the selected file."""
         filepath = self.input_files.get(stream)
+        df = None
         if not filepath:
             return default
         if filepath.endswith(".parquet"):
             import pyarrow.parquet as pq
-            return pq.read_table(filepath).to_pandas(safe=False)
-        catalog = self.read_catalog()
-        if catalog and catalog_types:
-            types_params = self.get_types_from_catalog(catalog, stream)
-            kwargs.update(types_params)
-        df = pd.read_csv(filepath, **kwargs)
-        if parse_objects:
+            df = pq.read_table(filepath).to_pandas(safe=False)
+        else:
+            catalog = self.read_catalog()
+            if catalog and catalog_types:
+                types_params = self.get_types_from_catalog(catalog, stream)
+                kwargs.update(types_params)
+            df = pd.read_csv(filepath, **kwargs)
+        if parse_objects and df is not None and not df.empty:
             df = parse_object_cols(df)
         return df
 

--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -441,6 +441,15 @@ def parse_objs(x):
     # if it's not a string, we just return the input
     if type(x) != str:
         return x
+    
+    # if it's a numeric type we don't want to parse it by accident
+    if type(x) == str:
+        try:
+            float(x)
+            return x
+        except:
+            # it failed so it's not a float or int, we can proceed
+            pass
 
     try:
         return ast.literal_eval(x)
@@ -550,7 +559,7 @@ class Reader:
     def __repr__(self):
         return str(list(self.input_files.keys()))
 
-    def get(self, stream, default=None, catalog_types=False, **kwargs):
+    def get(self, stream, default=None, catalog_types=False, parse_objects=False, **kwargs):
         """Read the selected file."""
         filepath = self.input_files.get(stream)
         if not filepath:
@@ -563,7 +572,8 @@ class Reader:
             types_params = self.get_types_from_catalog(catalog, stream)
             kwargs.update(types_params)
         df = pd.read_csv(filepath, **kwargs)
-        df = parse_object_cols(df)
+        if parse_objects:
+            df = parse_object_cols(df)
         return df
 
     def get_metadata(self, stream):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.1.21",
+    version="2.1.23",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Problem:
The get function assigns dtype "object" to all columns that are of type array or object in the catalog without parsing the data, which creates an stringified  invalid json. 

Steps to reproduce:
It happens for any css file with columns that have arrays or objects data inside.

Fix:
parse all the columns with dtype object when reading the df.