### PR TITLE
Hgi 6497 - handle multiple types for a col in get_types_from_catalog

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -661,6 +661,11 @@ class Reader:
         for col in headers:
             col_type = types.get(col)
             if col_type:
+                # if col has multiple types, use type with format if it not exists assign type object to support multiple types
+                any_of_list = col_type.get("anyOf", [])
+                if any_of_list:
+                    type_with_format = next((col_t for col_t in any_of_list if "format" in col_t), None)
+                    col_type = type_with_format if type_with_format else {"type": "object"}
                 if col_type.get("format") == "date-time":
                     parse_dates.append(col)
                     continue

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.1.22",
+    version="2.1.23",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
function `get_types_from_catalog` was not handling columns typed with `anyOf`, therefore not typing date-times properly.

