### PR TITLE
fix get func so all date columns are read as dates

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -562,7 +562,12 @@ class Reader:
         if catalog and catalog_types:
             types_params = self.get_types_from_catalog(catalog, stream)
             kwargs.update(types_params)
-        return pd.read_csv(filepath, **kwargs)
+        df = pd.read_csv(filepath, **kwargs)
+        # if a date field value is empty read_csv will read it as "object"
+        # make sure all date fields are typed as date
+        for date_col in kwargs.get("parse_dates", []):
+            df[date_col] = pd.to_datetime(df[date_col], errors='coerce')
+        return df
 
     def get_metadata(self, stream):
         """Get metadata from parquet file."""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.1.23",
+    version="2.1.24",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
**Problem:**

- When reading a csv file with `catalog_types=True`, if one of the rows has an empty field in a datetime column pandas will read that column as "object" instead of datetime.

**Solution:**

- Fixing the get function to make sure all datetime columns are read properly.