### PR TITLE
bump snapshotting coerce_types logic to handle NAN values for integers

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -212,6 +212,8 @@ def snapshot_records(
                     for column, dtype in df_types.items():
                         if dtype == 'bool':
                             merged_data[column] = merged_data[column].astype('boolean')
+                        elif dtype in ["int64", "int32", "Int32", "Int64"]:
+                            merged_data[column] = merged_data[column].astype("Int64")
                         else:
                             merged_data[column] = merged_data[column].astype(dtype)
                 except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.1.24",
+    version="2.1.25",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Problem:
- type coercion during snapshotting fails for int types if there are NAN values

Solution
- Use `Int64` for all integer dtypes, only `Int64` supports NAN values when casting a column to integers