### PR TITLE
HGI-7221: Fix coerce types and drop duplicates in snapshot_records

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.2.8",
+    version="2.2.9",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Problems:
- Type object was maintaining mixed types.
- Dropping duplicates not working as expected due to mixed types e.g.  3 and '3' are not considered the same value so both values were kept in the snapshot.

Changes:
- Coerce object type as string to have only one type per column so writing to parquet doesn't fail.
- Drop duplicates after coercing types.