### PR TITLE
HGi-7279 - Localize to UTC while parsing datetime

### DIFF
--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -97,7 +97,7 @@ class Reader:
         # if a date field value is empty read_csv will read it as "object"
         # make sure all date fields are typed as date
         for date_col in kwargs.get("parse_dates", []):
-            df[date_col] = pd.to_datetime(df[date_col], errors='coerce')
+            df[date_col] = pd.to_datetime(df[date_col], errors='coerce', utc=True)
 
         return df
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.2.9",
+    version="2.2.10",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When parsing CSVs, datetimes need to be localized to the same timezone in order to prevent the following error on 3.9:
```
ValueError: Array must be all same time zone
```