### PR TITLE
Hgi 7914: update to_singer and record_snapshot records

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -223,8 +223,6 @@ def snapshot_records(
                             merged_data[column] = merged_data[column].astype('boolean')
                         elif dtype in ["int64", "int32", "Int32", "Int64"]:
                             merged_data[column] = merged_data[column].astype("Int64")
-                        elif dtype == 'object':
-                            merged_data[column] = merged_data[column].astype(str)
                         else:
                             merged_data[column] = merged_data[column].astype(dtype)
                 except Exception as e:

--- a/gluestick/singer.py
+++ b/gluestick/singer.py
@@ -345,6 +345,10 @@ def to_singer(
     # drop columns with all null values except when we want to keep null fields
     if allow_objects and not (catalog_schema or include_all_unified_fields or keep_null_fields):
         df = df.dropna(how="all", axis=1)
+    else:
+        # df.dropna returns a new dataframe so df it's no longer pointing to the original dataframe, 
+        # if dropna is not applied we need to copy it or gen_singer_header will cast the original dataframe datetime columns as strings
+        df = df.copy()
 
     if catalog_schema or catalog_stream:
         # it'll allow_objects but keeping all columns

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.2.15",
+    version="2.2.16",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Changes:
- Remove casting for mixed types as "object" in `record_snapshots`, it was added for ticket `hgi-7221` and the root cause was the snapshots were wrong.
- Create a copy of the DataFrame in to_singer if `keep_null_fields` is True.
Why: When `keep_null_fields` is False, `df.dropna()` is called, which returns a new DataFrame by default. As a result, df is reassigned and no longer references the original DataFrame passed into `to_singer`. However, when `keep_null_fields` is True, dropna() is skipped, so df still references the original DataFrame. Later, `gen_singer_header` modifies df in-place (casting datetime columns to strings), and those changes unintentionally propagate back to the original DataFrame. 