### PR TITLE
HG-3867: remove transform from to_singer function

### DIFF
--- a/gluestick/singer.py
+++ b/gluestick/singer.py
@@ -369,15 +369,13 @@ def to_singer(
     with open(output, mode) as f:
         with redirect_stdout(f):
             singer.write_schema(stream, header_map, keys)
-            with Transformer() as transformer:
-                for _, row in df.iterrows():
-                    # keep null fields for catalog_schema, include_all_unified_fields and keep_null_fields
-                    if not (catalog_schema or include_all_unified_fields or keep_null_fields):
-                        filtered_row = row.dropna()
-                    else:
-                        filtered_row = row.where(pd.notna(row), None)
-                    filtered_row = filtered_row.to_dict()
-                    filtered_row = deep_convert_datetimes(filtered_row)
-                    rec = transformer.transform(filtered_row, header_map)
-                    singer.write_record(stream, rec)
-                singer.write_state({})
+            for _, row in df.iterrows():
+                # keep null fields for catalog_schema, include_all_unified_fields and keep_null_fields
+                if not (catalog_schema or include_all_unified_fields or keep_null_fields):
+                    filtered_row = row.dropna()
+                else:
+                    filtered_row = row.where(pd.notna(row), None)
+                filtered_row = filtered_row.to_dict()
+                filtered_row = deep_convert_datetimes(filtered_row)
+                singer.write_record(stream, filtered_row)
+            singer.write_state({})


### PR DESCRIPTION
Transform was adding extra time to the processing and it was redundant as the reading process in gluestick already enforces types from catalog.