### PR TITLE
HGI-8532: add get_id_from_snapshot and  read_target_catalog to gs

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -710,7 +710,7 @@ def exception(exception, root_dir, error_message=None):
         outfile.write(error)
     raise Exception(error)
 
-def get_id_from_snapshot(df, snapshot_dir, stream, flow_id, pk):
+def merge_id_from_snapshot(df, snapshot_dir, stream, flow_id, pk):
     """
     Merges DataFrame with target created snapshot to retrieve existing target ids.
     

--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -779,7 +779,7 @@ def get_id_from_snapshot(df, snapshot_dir, stream, flow_id, pk):
     print(f"Finished getting ids from snapshot for '{stream}'.")
     return merged
 
-def read_tenant_mapping(tenant_config, flow_id=None):
+def read_tenant_custom_mapping(tenant_config, flow_id=None):
     """Read the tenant mapping from the tenant config.
 
     Parameters

--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -195,6 +195,31 @@ class Reader:
         else:
             catalog = None
         return catalog
+    
+    def read_target_catalog(self, get_schemas=False):
+        """Read the target catalog.json file."""
+        filename = f"{self.root}/target-catalog.json"
+
+        if not os.path.exists(filename):
+            print(f"Target catalog not found at {filename}.")
+            return {}
+        
+        with open(filename, "r", encoding="utf-8") as f:
+            target_schemas_config = json.load(f)
+        
+        if not get_schemas:
+            return target_schemas_config
+        
+        target_stream_schemas = {}
+        if get_schemas and "streams" in target_schemas_config:
+            for stream_info in target_schemas_config["streams"]:
+                # Use 'stream' preferentially, fallback to 'tap_stream_id'
+                stream_name = stream_info.get("stream") or stream_info.get("tap_stream_id")
+                schema_properties = stream_info.get("schema", {}).get("properties", {})
+                if stream_name and schema_properties:
+                    target_stream_schemas[stream_name] = schema_properties
+                print(f"Finished loading target schemas for streams: {list(target_stream_schemas.keys())}")
+        return target_stream_schemas, target_schemas_config
 
     def get_types_from_catalog(self, catalog, stream, headers=None):
         """Get the pandas types base on the catalog definition.

--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -216,10 +216,13 @@ class Reader:
 
         if not os.path.exists(filename):
             print(f"Target catalog not found at {filename}.")
-            return {}
+            return None
         
         with open(filename, "r", encoding="utf-8") as f:
             raw_target_catalog = json.load(f)
+        
+        if process_schema:
+            return raw_target_catalog
         
         return raw_target_catalog , self.clean_catalog(raw_target_catalog)
 

--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -207,7 +207,7 @@ class Reader:
                 schema_properties = stream_info.get("schema", {}).get("properties", {})
                 if stream_name and schema_properties:
                     clean_catalog[stream_name] = schema_properties
-                print(f"Finished loading target schemas for streams: {list(clean_catalog.keys())}")
+        print(f"Finished loading target schemas for streams: {list(clean_catalog.keys())}")
         return clean_catalog
     
     def read_target_catalog(self, process_schema=False):

--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -196,7 +196,7 @@ class Reader:
             catalog = None
         return catalog
     
-    def read_target_catalog(self, get_schemas=False):
+    def read_target_catalog(self, process_schema=False):
         """Read the target catalog.json file."""
         filename = f"{self.root}/target-catalog.json"
 
@@ -207,11 +207,11 @@ class Reader:
         with open(filename, "r", encoding="utf-8") as f:
             target_schemas_config = json.load(f)
         
-        if not get_schemas:
+        if not process_schema:
             return target_schemas_config
         
         target_stream_schemas = {}
-        if get_schemas and "streams" in target_schemas_config:
+        if process_schema and "streams" in target_schemas_config:
             for stream_info in target_schemas_config["streams"]:
                 # Use 'stream' preferentially, fallback to 'tap_stream_id'
                 stream_name = stream_info.get("stream") or stream_info.get("tap_stream_id")

--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -188,11 +188,13 @@ class Reader:
 
     def read_catalog(self):
         """Read the catalog.json file."""
-        filen_name = f"{self.root}/catalog.json"
-        if os.path.isfile(filen_name):
-            with open(filen_name) as f:
+        file_name = f"{self.root}/catalog.json"
+        if os.path.isfile(file_name):
+            with open(file_name) as f:
                 catalog = json.load(f)
+            print(f"Finished loading source catalog.")
         else:
+            print(f"Source catalog not found at {file_name}.")
             catalog = None
         return catalog
     

--- a/gluestick/reader.py
+++ b/gluestick/reader.py
@@ -221,7 +221,7 @@ class Reader:
         with open(filename, "r", encoding="utf-8") as f:
             raw_target_catalog = json.load(f)
         
-        if process_schema:
+        if not process_schema:
             return raw_target_catalog
         
         return raw_target_catalog , self.clean_catalog(raw_target_catalog)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="2.2.22",
+    version="2.2.23",
     description="ETL utility functions built on Pandas",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Add `get_id_from_snapshot` function to merge working data frame with snapshot generated by target sdk to get the id (pk) for updates.
- Add `read_target_catalog` function to Reader to read the target catalog.
- Add `read_tenant_mapping` to read and process custom mapping in tenant-config.json