### PR TITLE
HGI-10878: write target state config on singer SCHEMA x-hotglue

### DIFF
--- a/gluestick/etl_utils.py
+++ b/gluestick/etl_utils.py
@@ -569,7 +569,9 @@ def to_export(
     output_file_prefix=os.environ.get("OUTPUT_FILE_PREFIX"), 
     schema=None, 
     stringify_objects=False, 
-    reserved_variables={}
+    reserved_variables={},
+    target_state_fields=None,
+    target_state_include_hash=False,
     ) -> None:
     raise NotImplementedError("to_export is not implemented for this dataframe type")
 
@@ -586,7 +588,9 @@ def pandas_df_to_export(
     schema=None,
     stringify_objects=False,
     reserved_variables={},
-    trim_nested_nulls=False
+    trim_nested_nulls=False,
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     """Parse a stringified dict or list of dicts.
 
@@ -620,6 +624,12 @@ def pandas_df_to_export(
         in the output_file_prefix.
     trim_nested_nulls: bool
         Flag for singer export to trim nulls from nested fields
+    target_state_fields: list[str] | str | None
+        Payload field names to persist in target state metadata (SCHEMA ``x-hotglue``).
+        Only used when ``export_format`` is ``singer``.
+    target_state_include_hash: bool
+        When True, request record hash inclusion in target state metadata.
+        Only used when ``export_format`` is ``singer``. Defaults to False.
 
     Returns
     -------
@@ -646,7 +656,18 @@ def pandas_df_to_export(
         reader = Reader()
         keys = keys or reader.get_pk(name)
         # export data as singer
-        to_singer(data, composed_name, output_dir, keys=keys, allow_objects=True, unified_model=unified_model, schema=schema, trim_nested_nulls=trim_nested_nulls)
+        to_singer(
+            data,
+            composed_name,
+            output_dir,
+            keys=keys,
+            allow_objects=True,
+            unified_model=unified_model,
+            schema=schema,
+            trim_nested_nulls=trim_nested_nulls,
+            target_state_fields=target_state_fields,
+            target_state_include_hash=target_state_include_hash,
+        )
     elif export_format == "parquet":
         if stringify_objects:
             data.to_parquet(
@@ -681,6 +702,8 @@ def polars_lf_to_export(
     stringify_objects=False,
     reserved_variables={},
     row_group_size: int | None = None,
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     """Write a Polars LazyFrame to a specified format.
 
@@ -715,6 +738,12 @@ def polars_lf_to_export(
     row_group_size: int | None
             The row group size to use for the output parquet file.
             If None, the row group size will be determined by the polars default.
+    target_state_fields: list[str] | str | None
+        Payload field names to persist in target state metadata (SCHEMA ``x-hotglue``).
+        Only used when ``export_format`` is ``singer``.
+    target_state_include_hash: bool
+        When True, request record hash inclusion in target state metadata.
+        Only used when ``export_format`` is ``singer``. Defaults to False.
 
     Returns
     -------
@@ -737,7 +766,17 @@ def polars_lf_to_export(
         reader = PLLazyFrameReader()
         keys = keys or reader.get_pk(name)
         # export data as singer
-        to_singer(data, composed_name, output_dir, keys=keys, allow_objects=True, unified_model=unified_model, schema=schema)
+        to_singer(
+            data,
+            composed_name,
+            output_dir,
+            keys=keys,
+            allow_objects=True,
+            unified_model=unified_model,
+            schema=schema,
+            target_state_fields=target_state_fields,
+            target_state_include_hash=target_state_include_hash,
+        )
     elif export_format == "parquet":
         data.sink_parquet(
             os.path.join(output_dir, f"{composed_name}.parquet"),
@@ -763,6 +802,8 @@ def polars_df_to_export(
     schema=None,
     stringify_objects=False,
     reserved_variables={},
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     """Write a Polars DataFrame to a specified format.
 
@@ -793,6 +834,12 @@ def polars_df_to_export(
     reserved_variables: dict
         A dictionary of default values for the format variables to be used
         in the output_file_prefix.
+    target_state_fields: list[str] | str | None
+        Payload field names to persist in target state metadata (SCHEMA ``x-hotglue``).
+        Only used when ``export_format`` is ``singer``.
+    target_state_include_hash: bool
+        When True, request record hash inclusion in target state metadata.
+        Only used when ``export_format`` is ``singer``. Defaults to False.
 
     Returns
     -------
@@ -815,7 +862,17 @@ def polars_df_to_export(
         reader = PolarsReader()
         keys = keys or reader.get_pk(name)
         # export data as singer
-        to_singer(data, composed_name, output_dir, keys=keys, allow_objects=True, unified_model=unified_model, schema=schema)
+        to_singer(
+            data,
+            composed_name,
+            output_dir,
+            keys=keys,
+            allow_objects=True,
+            unified_model=unified_model,
+            schema=schema,
+            target_state_fields=target_state_fields,
+            target_state_include_hash=target_state_include_hash,
+        )
     elif export_format == "parquet":
         data.write_parquet(
             os.path.join(output_dir, f"{composed_name}.parquet"),

--- a/gluestick/singer.py
+++ b/gluestick/singer.py
@@ -18,7 +18,7 @@ _DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 X_HOTGLUE_KEY = "x-hotglue"
 
 
-def build_x_hotglue(target_state_fields=None, target_state_include_hash=False):
+def build_x_hotglue(target_state_fields=None, target_state_include_hash=False) -> dict | None:
     """Build the ``x-hotglue`` envelope for Singer SCHEMA messages.
 
     Parameters

--- a/gluestick/singer.py
+++ b/gluestick/singer.py
@@ -15,6 +15,41 @@ import pytz
 from gluestick.reader import Reader
 
 _DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+X_HOTGLUE_KEY = "x-hotglue"
+
+
+def build_x_hotglue(target_state_fields=None, target_state_include_hash=False):
+    """Build the ``x-hotglue`` envelope for Singer SCHEMA messages.
+
+    Parameters
+    ----------
+    target_state_fields : list[str] | str | None
+        Field names from export payload records to include in target state metadata.
+        A single string is treated as a one-element list. Empty lists are ignored.
+    target_state_include_hash : bool
+        When True, add ``target_state_include_hash`` to the envelope.
+
+    Returns
+    -------
+    dict | None
+        The ``x-hotglue`` payload, or None when there is nothing to emit.
+    """
+    payload = {}
+
+    if target_state_fields is not None:
+        if isinstance(target_state_fields, str):
+            target_state_fields = [target_state_fields]
+        if not isinstance(target_state_fields, list):
+            raise ValueError("target_state_fields must be a string or list of strings")
+        if not all(isinstance(field, str) for field in target_state_fields):
+            raise ValueError("target_state_fields must contain only strings")
+        if target_state_fields:
+            payload["target_state_fields"] = target_state_fields
+
+    if target_state_include_hash:
+        payload["target_state_include_hash"] = True
+
+    return payload or None
 
 
 def _write_singer_message(msg: dict, fp=None) -> None:
@@ -32,8 +67,30 @@ def _write_singer_message(msg: dict, fp=None) -> None:
         fp.write(json.dumps(msg, default=str) + "\n")
 
 
-def write_schema(stream: str, schema: dict, key_properties, bookmark_properties=None, fp=None) -> None:
+def write_schema(
+    stream: str,
+    schema: dict,
+    key_properties,
+    bookmark_properties=None,
+    fp=None,
+    x_hotglue=None,
+) -> None:
     """Write a Singer SCHEMA message.
+
+    Parameters
+    ----------
+    stream : str
+        Stream name for the schema message.
+    schema : dict
+        JSON Schema describing stream records.
+    key_properties : list[str] | str
+        Primary key property names for the stream.
+    bookmark_properties : list[str] | None
+        Optional bookmark property names for the stream.
+    fp : file object | None
+        Optional file handle. Defaults to ``sys.stdout``.
+    x_hotglue : dict | None
+        Optional ``x-hotglue`` envelope written alongside the schema (target state config).
 
     Pass ``fp`` to write to an explicit file handle instead of ``sys.stdout``.
     """
@@ -44,6 +101,8 @@ def write_schema(stream: str, schema: dict, key_properties, bookmark_properties=
     msg = {"type": "SCHEMA", "stream": stream, "schema": schema, "key_properties": key_properties}
     if bookmark_properties:
         msg["bookmark_properties"] = bookmark_properties
+    if x_hotglue:
+        msg[X_HOTGLUE_KEY] = x_hotglue
     _write_singer_message(msg, fp=fp)
 
 
@@ -445,7 +504,9 @@ def to_singer(
     unified_model=None,
     keep_null_fields=False,
     catalog_stream=None,
-    recursive_typing=True
+    recursive_typing=True,
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     raise NotImplementedError("to_singer is not implemented for this type")
 
@@ -462,7 +523,9 @@ def pandas_df_to_singer(
     keep_null_fields=False,
     catalog_stream=None,
     trim_nested_nulls=False,
-    recursive_typing=True
+    recursive_typing=True,
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     """Convert a pandas DataFrame into a singer file.
 
@@ -490,6 +553,11 @@ def pandas_df_to_singer(
     recursive_typing: boolean
         If true, the function will recursively convert arrays of objects to arrays of primitives.
         If false, the function will fuzzy list types when generating singer header.
+    target_state_fields: list[str] | str | None
+        Payload field names to persist in target state metadata (written to SCHEMA ``x-hotglue``).
+    target_state_include_hash: bool
+        When True, request that the platform include the export record hash in target state.
+        Defaults to False.
     """
     catalog_schema = os.environ.get("USE_CATALOG_SCHEMA", "false").lower() == "true"
     include_all_unified_fields = os.environ.get("INCLUDE_ALL_UNIFIED_FIELDS", "false").lower() == "true" and unified_model is not None
@@ -521,9 +589,10 @@ def pandas_df_to_singer(
     do_trim = trim_nested_nulls and not keep_nulls
 
     chunk_size = int(os.environ.get("SINGER_CHUNK_SIZE", "20000"))
+    x_hotglue = build_x_hotglue(target_state_fields, target_state_include_hash)
 
     with open(output, mode) as f:
-        write_schema(stream, header_map, keys, fp=f)
+        write_schema(stream, header_map, keys, fp=f, x_hotglue=x_hotglue)
 
         n = len(df)
         for start in range(0, n, chunk_size):
@@ -616,7 +685,9 @@ def polars_df_to_singer(
     unified_model=None,
     keep_null_fields=False,
     catalog_stream=None,
-    recursive_typing=True
+    recursive_typing=True,
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     """Convert a polars DataFrame into a singer file.
 
@@ -642,18 +713,22 @@ def polars_df_to_singer(
     recursive_typing: boolean
         If true, the function will recursively convert arrays of objects to arrays of primitives.
         If false, the function will fuzzy list types when generating singer header.
+    target_state_fields: list[str] | str | None
+        Payload field names to persist in target state metadata (written to SCHEMA ``x-hotglue``).
+    target_state_include_hash: bool
+        When True, request that the platform include the export record hash in target state.
+        Defaults to False.
     """
 
     output = os.path.join(output_dir, filename)
     mode = "a" if os.path.isfile(output) else "w"
 
     header_map = gen_singer_header_from_polars_schema(df.schema)
- 
-
+    x_hotglue = build_x_hotglue(target_state_fields, target_state_include_hash)
 
     with open(output, mode) as f:
         with redirect_stdout(f):
-            write_schema(stream, header_map, keys)
+            write_schema(stream, header_map, keys, x_hotglue=x_hotglue)
             for row in df.iter_rows(named=True):
                 row = {k: v.strftime("%Y-%m-%dT%H:%M:%S.%fZ") if isinstance(v, datetime.datetime) else v for k, v in row.items()}
                 write_record(stream, row)
@@ -673,14 +748,16 @@ def polars_lf_to_singer(
     unified_model=None,
     keep_null_fields=False,
     catalog_stream=None,
-    recursive_typing=True
+    recursive_typing=True,
+    target_state_fields=None,
+    target_state_include_hash=False,
 ) -> None:
     """Convert a polars Lazyframe into a singer file.
 
     Parameters
     ----------
-    df: pd.DataFrame
-        Object to extract the types from.
+    df: pl.LazyFrame
+        Polars LazyFrame to convert to singer.
     stream: str
         Stream name to be used in the singer output file.
     output_dir: str
@@ -699,6 +776,11 @@ def polars_lf_to_singer(
     recursive_typing: boolean
         If true, the function will recursively convert arrays of objects to arrays of primitives.
         If false, the function will fuzzy list types when generating singer header.
+    target_state_fields: list[str] | str | None
+        Payload field names to persist in target state metadata (written to SCHEMA ``x-hotglue``).
+    target_state_include_hash: bool
+        When True, request that the platform include the export record hash in target state.
+        Defaults to False.
     """
 
     sink_fn = partial(
@@ -713,5 +795,7 @@ def polars_lf_to_singer(
         keep_null_fields=keep_null_fields,
         catalog_stream=catalog_stream,
         recursive_typing=recursive_typing,
+        target_state_fields=target_state_fields,
+        target_state_include_hash=target_state_include_hash,
     )
     df.sink_batches(sink_fn, chunk_size=1000)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="gluestick",
-    version="3.0.19",
+    version="3.0.20",
     description="ETL utility functions built for the hotglue iPaaS platform",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/function_tests/test_singer_protocol.py
+++ b/tests/function_tests/test_singer_protocol.py
@@ -10,7 +10,13 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from gluestick.singer import write_record, write_schema, write_state
+from gluestick.singer import (
+    X_HOTGLUE_KEY,
+    build_x_hotglue,
+    write_record,
+    write_schema,
+    write_state,
+)
 
 
 def _capture(capsys, fn, *args, **kwargs):
@@ -60,6 +66,57 @@ class TestWriteSchema:
         write_schema("s", {}, [])
         out = capsys.readouterr().out
         assert out.count("\n") == 1
+
+    def test_x_hotglue_included_when_set(self, capsys):
+        x_hotglue = {
+            "target_state_fields": ["email"],
+            "target_state_include_hash": True,
+        }
+        msgs = _capture(capsys, write_schema, "contacts", {"properties": {}}, [], x_hotglue=x_hotglue)
+        assert msgs[0][X_HOTGLUE_KEY] == x_hotglue
+
+    def test_x_hotglue_omitted_when_not_set(self, capsys):
+        msgs = _capture(capsys, write_schema, "contacts", {"properties": {}}, [])
+        assert X_HOTGLUE_KEY not in msgs[0]
+
+
+class TestBuildXHotglue:
+    def test_returns_none_when_unset(self):
+        assert build_x_hotglue() is None
+        assert build_x_hotglue(target_state_fields=[]) is None
+        assert build_x_hotglue(target_state_include_hash=False) is None
+
+    def test_fields_only(self):
+        assert build_x_hotglue(target_state_fields=["email", "status"]) == {
+            "target_state_fields": ["email", "status"],
+        }
+
+    def test_single_field_string_coerced_to_list(self):
+        assert build_x_hotglue(target_state_fields="email") == {
+            "target_state_fields": ["email"],
+        }
+
+    def test_include_hash_only(self):
+        assert build_x_hotglue(target_state_include_hash=True) == {
+            "target_state_include_hash": True,
+        }
+
+    def test_fields_and_include_hash(self):
+        assert build_x_hotglue(
+            target_state_fields=["email"],
+            target_state_include_hash=True,
+        ) == {
+            "target_state_fields": ["email"],
+            "target_state_include_hash": True,
+        }
+
+    def test_invalid_fields_type_raises(self):
+        with pytest.raises(ValueError):
+            build_x_hotglue(target_state_fields=123)
+
+    def test_non_string_field_names_raise(self):
+        with pytest.raises(ValueError):
+            build_x_hotglue(target_state_fields=["email", 1])
 
 
 class TestWriteRecord:

--- a/tests/function_tests/test_to_export.py
+++ b/tests/function_tests/test_to_export.py
@@ -8,6 +8,7 @@ import polars as pl
 import pytest
 
 from gluestick.etl_utils import to_export
+from gluestick.singer import X_HOTGLUE_KEY
 
 
 def _pd_small():
@@ -41,6 +42,25 @@ def test_pandas_singer_creates_data_singer(tmp_path):
     lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
     types = {x["type"] for x in lines}
     assert "SCHEMA" in types and "RECORD" in types and "STATE" in types
+
+
+def test_pandas_singer_writes_x_hotglue_from_to_export(tmp_path):
+    df = pd.DataFrame({"externalId": ["a"], "email": ["a@example.com"]})
+    to_export(
+        df,
+        name="Contacts",
+        output_dir=str(tmp_path),
+        keys=["externalId"],
+        export_format="singer",
+        target_state_fields=["email"],
+        target_state_include_hash=True,
+    )
+    lines = [json.loads(line) for line in (Path(tmp_path) / "data.singer").read_text().splitlines() if line.strip()]
+    schema = next(line for line in lines if line["type"] == "SCHEMA")
+    assert schema[X_HOTGLUE_KEY] == {
+        "target_state_fields": ["email"],
+        "target_state_include_hash": True,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/function_tests/test_to_singer.py
+++ b/tests/function_tests/test_to_singer.py
@@ -10,7 +10,7 @@ import datetime
 
 import pandas as pd
 import polars as pl
-from gluestick.singer import to_singer, gen_singer_header_from_polars_schema
+from gluestick.singer import X_HOTGLUE_KEY, to_singer, gen_singer_header_from_polars_schema
 
 
 def _read_singer_lines(path):
@@ -69,6 +69,54 @@ class TestToSingerBasic:
         to_singer(df, "invoices", str(tmp_path), keys=["invoice_id"])
         schema = _get_schema(_read_singer_lines(tmp_path / "data.singer"))
         assert schema["key_properties"] == ["invoice_id"]
+
+
+class TestTargetStateXHotglue:
+    def test_omitted_by_default(self, tmp_path):
+        df = pd.DataFrame({"externalId": ["a"], "email": ["a@example.com"]})
+        to_singer(df, "Contacts", str(tmp_path), keys=["externalId"])
+        schema = _get_schema(_read_singer_lines(tmp_path / "data.singer"))
+        assert X_HOTGLUE_KEY not in schema
+
+    def test_writes_target_state_fields(self, tmp_path):
+        df = pd.DataFrame({"externalId": ["a"], "email": ["a@example.com"]})
+        to_singer(
+            df,
+            "Contacts",
+            str(tmp_path),
+            keys=["externalId"],
+            target_state_fields=["email", "status"],
+        )
+        schema = _get_schema(_read_singer_lines(tmp_path / "data.singer"))
+        assert schema[X_HOTGLUE_KEY] == {"target_state_fields": ["email", "status"]}
+
+    def test_writes_include_hash_when_true(self, tmp_path):
+        df = pd.DataFrame({"externalId": ["a"]})
+        to_singer(
+            df,
+            "Contacts",
+            str(tmp_path),
+            keys=["externalId"],
+            target_state_include_hash=True,
+        )
+        schema = _get_schema(_read_singer_lines(tmp_path / "data.singer"))
+        assert schema[X_HOTGLUE_KEY] == {"target_state_include_hash": True}
+
+    def test_writes_both_fields(self, tmp_path):
+        df = pd.DataFrame({"externalId": ["a"], "email": ["a@example.com"]})
+        to_singer(
+            df,
+            "Contacts",
+            str(tmp_path),
+            keys=["externalId"],
+            target_state_fields=["email"],
+            target_state_include_hash=True,
+        )
+        schema = _get_schema(_read_singer_lines(tmp_path / "data.singer"))
+        assert schema[X_HOTGLUE_KEY] == {
+            "target_state_fields": ["email"],
+            "target_state_include_hash": True,
+        }
 
 
 class TestNullHandling:


### PR DESCRIPTION
Adds gluestick support for the `x-hotglue` target state contract from HGI-10878. 

ETL scripts can pass `target_state_fields` and `target_state_include_hash` through `to_export` / `to_singer`, and gluestick writes them on the Singer SCHEMA message. The hotglue executor reads that envelope when building ID snapshot CSVs and merges the selected payload fields (and optional record hash) into `CustomData`.

## Changed files

- **gluestick/singer.py** — `build_x_hotglue`, `X_HOTGLUE_KEY`, `write_schema` x-hotglue support, wire params through all `to_singer` implementations.
- **gluestick/etl_utils.py** — pass `target_state_fields` / `target_state_include_hash` from `to_export` into `to_singer`.
- **setup.py** — bump version to 3.0.20.
- **tests/function_tests/test_singer_protocol.py** — unit tests for `build_x_hotglue` and `write_schema`.
- **tests/function_tests/test_to_singer.py** — integration tests for default omission and both params.
- **tests/function_tests/test_to_export.py** — end-to-end test through `to_export`.